### PR TITLE
Update batch_renorm.py doc string

### DIFF
--- a/batch_renorm.py
+++ b/batch_renorm.py
@@ -61,6 +61,7 @@ class BatchRenormalization(Layer):
     # Output shape
         Same shape as input.
     # References
+        - [Batch Renormalization: Towards Reducing Minibatch Dependence in Batch-Normalized Models](https://arxiv.org/abs/1702.03275)
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
     """
 


### PR DESCRIPTION
In the doc string of class BatchRenormalization, under the # Reference, you only mentioned the batch normalization paper, I added the batch renormalization paper link.